### PR TITLE
Add entry point for Flutter app

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,17 +37,17 @@ HydroField is a cross-platform field data collection tool for anyone in hydrogra
 
 3. Run the app:
    ```bash
-   flutter run
+   flutter run main.dart
    ```
 
 ## Folder Structure
 
 ```
-/lib
-  /models         # Data models
-  /screens        # UI screens
-  /services       # Sync, storage, sensors
-/specs
+main.dart        # Application entry point
+models/          # Data models
+screens/         # UI screens
+services/        # Sync, storage, sensors
+specs/
   hydrofield_spec.md
 ```
 

--- a/main.dart
+++ b/main.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'screens/field_activity_session_screen.dart';
+import 'screens/stream_survey_screen.dart';
+import 'screens/stream_survey_list_screen.dart';
+import 'screens/sample_list_screen.dart';
+import 'screens/log_screen.dart';
+
+void main() {
+  runApp(const HydroFieldApp());
+}
+
+class HydroFieldApp extends StatelessWidget {
+  const HydroFieldApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'HydroField',
+      theme: ThemeData(primarySwatch: Colors.blue),
+      home: const HomeScreen(),
+    );
+  }
+}
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('HydroField')),
+      body: ListView(
+        children: [
+          ListTile(
+            title: const Text('Field Activity Sessions'),
+            onTap: () => Navigator.of(context).push(
+              MaterialPageRoute(builder: (_) => const FieldActivitySessionScreen()),
+            ),
+          ),
+          ListTile(
+            title: const Text('New Stream Survey Point'),
+            onTap: () => Navigator.of(context).push(
+              MaterialPageRoute(builder: (_) => const StreamSurveyScreen()),
+            ),
+          ),
+          ListTile(
+            title: const Text('Unsynced Stream Surveys'),
+            onTap: () => Navigator.of(context).push(
+              MaterialPageRoute(builder: (_) => const StreamSurveyListScreen()),
+            ),
+          ),
+          ListTile(
+            title: const Text('Unsynced Water Samples'),
+            onTap: () => Navigator.of(context).push(
+              MaterialPageRoute(builder: (_) => const SampleListScreen()),
+            ),
+          ),
+          ListTile(
+            title: const Text('Activity Log'),
+            onTap: () => Navigator.of(context).push(
+              MaterialPageRoute(builder: (_) => const LogScreen()),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create `main.dart` with MaterialApp and simple home screen
- update README with run instructions and folder structure

## Testing
- `ls -R | grep test`

------
https://chatgpt.com/codex/tasks/task_e_68812589cf808332975fca8ca0239914