### PR TITLE
Add basic model test scripts

### DIFF
--- a/test/model_field_activity_session_test.dart
+++ b/test/model_field_activity_session_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hydrofield/models/field_activity_session.dart';
+
+void main() {
+  test('FieldActivitySession toMap/fromMap round trip', () {
+    final session = FieldActivitySession(
+      stationCode: 'ST001',
+      userName: 'Tester',
+      startTime: DateTime.parse('2024-01-01T12:00:00Z'),
+      endTime: DateTime.parse('2024-01-01T13:00:00Z'),
+      notes: 'note',
+      synced: true,
+    );
+
+    final map = session.toMap();
+    final from = FieldActivitySession.fromMap(map);
+
+    expect(from.id, session.id);
+    expect(from.stationCode, session.stationCode);
+    expect(from.userName, session.userName);
+    expect(from.startTime.toUtc(), session.startTime.toUtc());
+    expect(from.endTime!.toUtc(), session.endTime!.toUtc());
+    expect(from.notes, session.notes);
+    expect(from.synced, session.synced);
+  });
+}
+

--- a/test/model_stream_survey_test.dart
+++ b/test/model_stream_survey_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hydrofield/models/stream_survey.dart';
+
+void main() {
+  test('StreamSurvey toMap/fromMap round trip', () {
+    final survey = StreamSurvey(
+      timestamp: DateTime.parse('2024-01-03T10:15:00Z'),
+      chainage: 50.0,
+      elevation: 12.3,
+      angle: 5.5,
+      reducedLevel: 11.0,
+      compassHeading: 180.0,
+      notes: 'survey note',
+      synced: true,
+    );
+
+    final map = survey.toMap();
+    final from = StreamSurvey.fromMap(map);
+
+    expect(from.id, survey.id);
+    expect(from.timestamp.toUtc(), survey.timestamp.toUtc());
+    expect(from.chainage, survey.chainage);
+    expect(from.elevation, survey.elevation);
+    expect(from.angle, survey.angle);
+    expect(from.reducedLevel, survey.reducedLevel);
+    expect(from.compassHeading, survey.compassHeading);
+    expect(from.notes, survey.notes);
+    expect(from.synced, survey.synced);
+  });
+}
+

--- a/test/model_water_sample_test.dart
+++ b/test/model_water_sample_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hydrofield/models/water_sample.dart';
+
+void main() {
+  test('WaterSample toMap/fromMap round trip', () {
+    final sample = WaterSample(
+      sampleId: 'WS001',
+      timestamp: DateTime.parse('2024-01-02T14:30:00Z'),
+      latitude: 40.0,
+      longitude: -105.0,
+      elevation: 1000.0,
+      collectorName: 'Tester',
+      temperature: 20.5,
+      notes: 'sample note',
+      photoPath: '/tmp/photo.jpg',
+      cocCsvPath: '/tmp/coc.csv',
+      synced: true,
+    );
+
+    final map = sample.toMap();
+    final from = WaterSample.fromMap(map);
+
+    expect(from.id, sample.id);
+    expect(from.sampleId, sample.sampleId);
+    expect(from.timestamp.toUtc(), sample.timestamp.toUtc());
+    expect(from.latitude, sample.latitude);
+    expect(from.longitude, sample.longitude);
+    expect(from.elevation, sample.elevation);
+    expect(from.collectorName, sample.collectorName);
+    expect(from.temperature, sample.temperature);
+    expect(from.notes, sample.notes);
+    expect(from.photoPath, sample.photoPath);
+    expect(from.cocCsvPath, sample.cocCsvPath);
+    expect(from.synced, sample.synced);
+  });
+}
+


### PR DESCRIPTION
## Summary
- create a `test` directory with unit tests
- validate toMap/fromMap conversions for FieldActivitySession, WaterSample and StreamSurvey models

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688131c04dec833291bd00652d65b342